### PR TITLE
メッセージ送信の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
@@ -61,3 +61,4 @@ gem 'devise'
 gem 'pry-rails'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,14 +45,6 @@ GEM
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.32.1)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.5)
-      xpath (~> 3.2)
     carrierwave (2.1.0)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -176,7 +168,6 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (1.7.0)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -230,9 +221,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -247,15 +235,12 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
-  capybara
   carrierwave
   coffee-rails (~> 4.2)
   devise
@@ -276,7 +261,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -52,10 +52,11 @@ $(function(){
       $('.messages').append(html);
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
       $('form')[0].reset();
-      $('.send-btn').removeAttr('disabled');
     })
     .fail(function(){
       alert("メッセージ送信に失敗しました");
+    })
+    .always(function(){
       $('.send-btn').removeAttr('disabled');
     })
   });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,62 @@
+$(function(){
+
+  function buildHTML(message){
+    if (message.image) {
+      var html = `<div class="message">
+                    <div class="message__upper">
+                      <div class="message__upper__name">
+                        ${message.user_name}
+                      </div>
+                      <div class="message__upper__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="message__text">
+                      ${message.content}
+                      <img class="message-image" src=${message.image}>
+                    </div>
+                  </div>`
+      return html;
+    } else {
+      var html = `<div class="message">
+                    <div class="message__upper">
+                      <div class="message__upper__name">
+                        ${message.user_name}
+                      </div>
+                      <div class="message__upper__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="message__text">
+                      ${message.content}
+                    </div>
+                  </div>`
+      return html;
+    };
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+      $('form')[0].reset();
+      $('.send-btn').removeAttr('disabled');
+    })
+    .fail(function(){
+      alert("メッセージ送信に失敗しました");
+      $('.send-btn').removeAttr('disabled');
+    })
+  });
+});

--- a/app/assets/stylesheets/modules/_chat.scss
+++ b/app/assets/stylesheets/modules/_chat.scss
@@ -50,6 +50,7 @@
     width: 100%;
     background-color: #fafafa;
     padding: 35px 40px;
+    overflow: scroll;
     .message {
       padding-bottom: 46px;
       &__upper {

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# What
チャットスペースのメッセージ送信機能を非同期化するコードの追加。

# Why
更新なしで通信できることで、チャットの流れをよりスムーズにするため。

### GIF URL↓
メッセージ送信（[https://gyazo.com/4c308bfd81cc1d4a4f608aa61b6c4ac0](url)）
画像のみ送信（[https://gyazo.com/829745d67bf8b274ebf6a209c7ab8674](url)）
メッセージ＋画像（[https://gyazo.com/cdae9a5a0c6951d0decef4998b10d3fe](url)）